### PR TITLE
feat: support c8y basic auth

### DIFF
--- a/src/tedge/tedge.default.toml
+++ b/src/tedge/tedge.default.toml
@@ -3,6 +3,9 @@ version = "2"
 
 [c8y]
 root_cert_path = "@CONFIG_DIR@/ca-certificates.crt"
+# Use basic auth if credentials file is present, otherwise use certificates
+auth_method = "auto"
+credentials_path = "@CONFIG_DIR@/credentials"
 
 [az]
 root_cert_path = "@CONFIG_DIR@/ca-certificates.crt"


### PR DESCRIPTION
Support c8y basic authentication if a `credentials` file is present.

file: `{install_path}/tedge/credentials`

```toml
[c8y]
username = "t12345/device_<device-id>"
password = "...."
```