### PR TITLE
feat: use toml extension for credentials.toml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Before running the `boostrap.sh` script, you will need to set the device's crede
 For example, if you installed thin-edge.io under `/data` then you can set the credentials using the following snippet:
 
 ```sh
-cat <<EOT > /data/tedge/credentials
+cat <<EOT > /data/tedge/credentials.toml
 [c8y]
 username = "{tenant}/device_{external_id}"
 password = "{password}"

--- a/src/tedge/tedge.default.toml
+++ b/src/tedge/tedge.default.toml
@@ -5,7 +5,7 @@ version = "2"
 root_cert_path = "@CONFIG_DIR@/ca-certificates.crt"
 # Use basic auth if credentials file is present, otherwise use certificates
 auth_method = "auto"
-credentials_path = "@CONFIG_DIR@/credentials"
+credentials_path = "@CONFIG_DIR@/credentials.toml"
 
 [az]
 root_cert_path = "@CONFIG_DIR@/ca-certificates.crt"


### PR DESCRIPTION
Since https://github.com/thin-edge/thin-edge.io/pull/3219 is merged, the default credentials file name should be `credentials.toml`. Technically this path does not need to be set anymore, however it will make it easier for the user to know where to put the file (if using basic auth).