### PR TITLE
feat: use official thin-edge.io release channel (not main branch)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  TEDGE_CHANNEL: main
+  TEDGE_CHANNEL: release
 
 jobs:
   build:


### PR DESCRIPTION
The features used by this repository are now included in the official thin-edge.io release 1.4.1