### PR TITLE
fix: exclude variable replacement for binaries to improve compat with low memory devices

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,7 +72,9 @@ done
 update_install_path() {
     src="$1"
     value="$2"
-    find "$src" -type f -exec sed -i s%@CONFIG_DIR@%"${value}"%g {} \;
+    # exclude binaries as this can cause additional memory usage which is a problem on smaller devices < 34MB RAM
+    # like the Luckfox Pico
+    find "$src" -type f ! -name tedge ! -name mosquitto -exec sed -i s%@CONFIG_DIR@%"${value}"%g {} \;
 }
 
 decompress_archive() {


### PR DESCRIPTION
On low-memory (<33MB RAM) devices like the Luckfox Pico, using sed in-line replacement on binaries can cause out-of-memory events. Since the binaries didn't require any text replacements anyway, they are explicitly excluded from the search.