### PR TITLE
build: publish both upx'd versions and non compressed versions of the tarball

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,15 +37,19 @@ jobs:
         with:
           fetch-depth: 0
       - uses: taiki-e/install-action@just
-      - name: Build
-        run: just build ${{ matrix.target.arch }} ${{ matrix.target.name }}
+      - name: Build (with upx)
+        run: just build ${{ matrix.target.arch }} ${{ matrix.target.name }}-upx
+      - name: Build (without upx)
+        run: just build ${{ matrix.target.arch }} ${{ matrix.target.name }} --skip-upx
 
       - name: Upload packages as zip
         # https://github.com/marketplace/actions/upload-a-build-artifact
         uses: actions/upload-artifact@v4
         with:
             name: tedge-standalone-${{ matrix.target.name }}
-            path: tedge-standalone-${{ matrix.target.name }}.tar.gz
+            path: |
+              tedge-standalone-${{ matrix.target.name }}-upx.tar.gz
+              tedge-standalone-${{ matrix.target.name }}.tar.gz
 
   release:
     runs-on: ubuntu-latest

--- a/install.sh
+++ b/install.sh
@@ -5,6 +5,7 @@ INSTALL_PATH="${INSTALL_PATH:-/data}"
 VERSION="${VERSION:-0.6.0}"
 INSTALL_FILE="${INSTALL_FILE:-}"
 OVERWRITE_CONFIG=0
+VERSION_SUFFIX="${VERSION_SUFFIX:-"-upx"}"
 
 usage() {
     cat << EOT
@@ -12,13 +13,16 @@ Install thin-edge.io standalone package for running on resource constrained devi
 without any accessible init system.
 
 USAGE
-    $0 [--install-path <path>] [--version <version>]
+    $0 [--install-path <path>] [--version <version>] [--no-upx]
 
 ARGUMENTS
   --install-path <path>         Install path. Defaults to $INSTALL_PATH
   --version <version>           Version to install. Defaults to $VERSION
   --file <path>                 Install from a file instead of downloading it
   --overwrite                   Overwrite any existing configuration
+  --upx                         Use upx'd versions of the binaries (Default).
+                                Useful for devices with very limited disk space (< 10MB) and have memory more than 64MB
+  --no-upx                      Don't download the upx'd version (e.g. recommended for low-memory devices)
 
 EXAMPLE
 
@@ -27,6 +31,9 @@ EXAMPLE
 
     $0 --install-path /data
     # Install under a custom location
+
+    $0 --install-path /data --no-upx
+    # Install under a custom location but install the non-upx'd versions
 
     $0 --install-path /home/etc --overwrite
     # Install under a custom location and overrite any existing configuration files
@@ -41,6 +48,12 @@ while [ $# -gt 0 ]; do
         --install-path)
             INSTALL_PATH="$2"
             shift
+            ;;
+        --upx)
+            VERSION_SUFFIX="-upx"
+            ;;
+        --no-upx)
+            VERSION_SUFFIX=""
             ;;
         --file)
             INSTALL_FILE="$2"
@@ -124,7 +137,7 @@ install_from_web() {
     esac
 
     cd /tmp
-    wget -q "https://github.com/thin-edge/tedge-standalone/releases/download/$VERSION/tedge-standalone-${TARGET_ARCH}.tar.gz"
+    wget -q "https://github.com/thin-edge/tedge-standalone/releases/download/$VERSION/tedge-standalone-${TARGET_ARCH}${VERSION_SUFFIX}.tar.gz"
     mkdir -p "$INSTALL_PATH"
     echo "Installing thin-edge.io to $INSTALL_PATH/tedge"
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,6 +10,7 @@ TARGET_NAME="$2"
 PACKAGE="${PACKAGE:-}"
 TEDGE_VERSION="${TEDGE_VERSION:-}"
 TEDGE_CHANNEL="${TEDGE_CHANNEL:-}"
+SKIP_UPX="${SKIP_UPX:-}"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -33,6 +34,9 @@ while [ $# -gt 0 ]; do
             TEDGE_CHANNEL="$2"
             shift
             ;;
+        --skip-upx)
+            SKIP_UPX=1
+            ;;
     esac
     shift
 done
@@ -51,8 +55,12 @@ if [ -z "$TEDGE_VERSION" ]; then
     TEDGE_VERSION=$(curl -s "https://dl.cloudsmith.io/public/thinedge/tedge-${TEDGE_CHANNEL}/raw/names/tedge-arm64/versions/latest/tedge.tar.gz" --write-out '%{redirect_url}' | rev | cut -d/ -f2 | rev)
 fi
 
-SKIP_UPX=0
+if [ -z "$SKIP_UPX" ]; then
+    SKIP_UPX=0
+fi
+
 if [ "$TARGET" = "riscv64-linux" ]; then
+    # risc64 does not support upx, so ensure it is disabled
     SKIP_UPX=1
 fi
 


### PR DESCRIPTION
On some devices like the Luckfox Pico, the upx'd versions of the binaries do not run as they trigger an out-of-memory error due to only have ~34MB of RAM and upx works by first expanding the binary into memory and this memory is never release (limitation of upx).

The default is still as before to use the upx'd versions, however this may change in the future.