### PR TITLE
feat: add support for Luckfox Pico devices

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,9 +38,9 @@ jobs:
           fetch-depth: 0
       - uses: taiki-e/install-action@just
       - name: Build (with upx)
-        run: just build ${{ matrix.target.arch }} ${{ matrix.target.name }}-upx
+        run: just build ${{ matrix.target.arch }} ${{ matrix.target.name }}
       - name: Build (without upx)
-        run: just build ${{ matrix.target.arch }} ${{ matrix.target.name }} --skip-upx
+        run: just build ${{ matrix.target.arch }} ${{ matrix.target.name }}-noupx --skip-upx
 
       - name: Upload packages as zip
         # https://github.com/marketplace/actions/upload-a-build-artifact

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This repository shows how thin-edge.io can be packaged and installed on a device which has the following constraints:
 
-* device has less than 5 MB disk space on the read-write partition
+* device has very little disk space on the read-write partition
+    * Requires 5MB  - when using compressed (upx'd) binaries
+    * Requires 14MB - when using uncompressed (non-upx'd) binaries
 * device uses a read-only root filesystem (rootfs) which results in the following restrictions:
     * Can't add or modify services in the init system -> need custom init system
     * Can't add linux users or groups -> need to run services as **root**
@@ -65,6 +67,7 @@ If your device is listed below, then you can follow the device specific instruct
 
 * [PSsystec](./docs/PSsystec.md)
 * [Advantech](./docs/ADVANTECH.md)
+* [Luckfox Pico](./docs/Luckfox.md)
 
 
 ### General instructions

--- a/docs/Luckfox.md
+++ b/docs/Luckfox.md
@@ -1,0 +1,53 @@
+# Luckfox
+
+## Luckfox Pico
+
+The default busybox based Luckfox images don't include any tools to download files using TLS (e.g. for downloading files using HTTPS), and even it it does, it would need a root certificate trust store (e.g. ca-certificates.crt) before it could even trust those services. Because of this, it is recommended to download the standalone file and then transfer it to the device where it can be installed locally.
+
+Install thin-edge.io standalone on a Luckfox Pico device using the following steps:
+
+1. Download the latest standalone file from the releases page onto your current machine. Download the `armhf` version without the `-upx` in the file name.
+
+2. Copy the standalone file and the install script to the device
+
+    **Using ADB**
+
+    ```sh
+    adm push "./install.sh" /tmp/install.sh
+    adm push ./tedge-standalone-armhf-*.tar.gz /tmp/tedge-standalone-armhf.tar.gz
+    ```
+
+    **Using SSH**
+
+    Replace the IP address (`192.168.68.71`) with the relevant IP address for your device.
+
+    ```sh
+    scp -o PreferredAuthentications=password -o PubkeyAuthentication=no "./install.sh" root@192.168.68.71:/tmp/install.sh
+    scp ./tedge-standalone-armhf*.tar.gz root@192.168.68.71:/tmp/
+    ```
+
+1. SSH into the device
+
+    ```sh
+    ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no root@192.168.68.71
+    ```
+
+3. Run the installer script on the device
+
+    ```sh
+    chmod +x /tmp/install.sh
+    /tmp/install.sh --file /tmp/tedge-standalone-armhf*.tar.gz --install-path /opt
+    ```
+
+    Afterwards you can delete both the installer and tar.gz file.
+
+    ```sh
+    rm /tmp/install.sh
+    rm /tmp/tedge-standalone-armhf*.tar.gz
+    ```
+
+4. Bootstrap the device
+
+    ```sh
+    /opt/tedge/bootstrap.sh
+    ```

--- a/docs/Luckfox.md
+++ b/docs/Luckfox.md
@@ -23,7 +23,7 @@ Install thin-edge.io standalone on a Luckfox Pico device using the following ste
 
     ```sh
     scp -o PreferredAuthentications=password -o PubkeyAuthentication=no "./install.sh" root@192.168.68.71:/tmp/install.sh
-    scp ./tedge-standalone-armhf*.tar.gz root@192.168.68.71:/tmp/
+    scp -o PreferredAuthentications=password -o PubkeyAuthentication=no ./tedge-standalone-armhf*.tar.gz root@192.168.68.71:/tmp/
     ```
 
 1. SSH into the device
@@ -35,8 +35,7 @@ Install thin-edge.io standalone on a Luckfox Pico device using the following ste
 3. Run the installer script on the device
 
     ```sh
-    chmod +x /tmp/install.sh
-    /tmp/install.sh --file /tmp/tedge-standalone-armhf*.tar.gz --install-path /opt
+    sh /tmp/install.sh --file /tmp/tedge-standalone-armhf*.tar.gz --install-path /opt
     ```
 
     Afterwards you can delete both the installer and tar.gz file.

--- a/install.sh
+++ b/install.sh
@@ -185,6 +185,10 @@ main() {
     echo
     echo "    $INSTALL_PATH/tedge/bootstrap.sh"
     echo
+    echo Import the shell environment using:
+    echo
+    echo "    set -a; . '$INSTALL_PATH/tedge/env'; set +a"
+    echo
 }
 
 main

--- a/install.sh
+++ b/install.sh
@@ -50,10 +50,10 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         --upx)
-            VERSION_SUFFIX="-upx"
+            VERSION_SUFFIX=""
             ;;
         --no-upx)
-            VERSION_SUFFIX=""
+            VERSION_SUFFIX="-noupx"
             ;;
         --file)
             INSTALL_FILE="$2"

--- a/src/tedge/bootstrap.sh
+++ b/src/tedge/bootstrap.sh
@@ -33,9 +33,6 @@ if command -V runsvdir >/dev/null 2>&1; then
     fi
 
     mkdir -p "$SVDIR"
-    # tedgectl enable mosquitto
-    # tedgectl enable tedge-agent
-    # tedgectl enable tedge-mapper-c8y
 
     # Start runit in the background
     if ! pgrep -f "runsvdir -P $SVDIR" >/dev/null 2>&1; then
@@ -52,17 +49,6 @@ elif [ -d /etc/init.d ]; then
     cp "@CONFIG_DIR@/services-init.d"/S[0-9][0-9]* /etc/init.d/
     rm -f "@CONFIG_DIR@/bin/tedgectl"
     ln -s "@CONFIG_DIR@/services-init.d/tedgectl" "@CONFIG_DIR@/bin/tedgectl"
-
-    # tedgectl enable mosquitto
-    # tedgectl enable tedge-agent
-    # tedgectl enable tedge-mapper-c8y
-
-    # echo "Starting services using init.d scripts" >&2
-    # tedgectl start mosquitto
-    # sleep 1
-    # tedgectl start tedge-agent
-    # sleep 1
-    # tedgectl start tedge-mapper-c8y
 else
     echo "WARNING: Could not start services as 'runsvdir' is not installed. You will need to start the services yourself" >&2
 fi

--- a/src/tedge/bootstrap.sh
+++ b/src/tedge/bootstrap.sh
@@ -10,6 +10,65 @@ fi
 # Init (also creating the multi-call binary symlinks)
 tedge init --user root --group root
 
+#
+# Configure services if runit is installed
+#
+if command -V runsvdir >/dev/null 2>&1; then
+    #
+    # Setup runit services
+    #
+    if ! grep -q '^SVDIR=/.*' @CONFIG_DIR@/env; then
+        if [ -d /var/run ]; then
+            SVDIR=/var/run/services
+        elif [ -d /run ]; then
+            SVDIR=/run/services
+        elif [ -d /tmp ]; then
+            SVDIR=/tmp/services
+        else
+            echo "Could not find a volatile directory for the runit services" >&2
+            exit 1
+        fi
+        echo "SVDIR=$SVDIR" >> "@CONFIG_DIR@/env"
+        export SVDIR
+    fi
+
+    mkdir -p "$SVDIR"
+    # tedgectl enable mosquitto
+    # tedgectl enable tedge-agent
+    # tedgectl enable tedge-mapper-c8y
+
+    # Start runit in the background
+    if ! pgrep -f "runsvdir -P $SVDIR" >/dev/null 2>&1; then
+        echo "Starting services using runit: runsvdir -P \"$SVDIR/\" &" >&2
+        runsvdir -P "$SVDIR/" &
+    else
+        echo "Services are already running via: runsvdir -P \"$SVDIR\""
+    fi
+elif [ -d /etc/init.d ]; then
+    #
+    # Setup SysVInit services
+    #
+    echo "Using /etc/init.d service definitions" >&2
+    cp "@CONFIG_DIR@/services-init.d"/S[0-9][0-9]* /etc/init.d/
+    rm -f "@CONFIG_DIR@/bin/tedgectl"
+    ln -s "@CONFIG_DIR@/services-init.d/tedgectl" "@CONFIG_DIR@/bin/tedgectl"
+
+    # tedgectl enable mosquitto
+    # tedgectl enable tedge-agent
+    # tedgectl enable tedge-mapper-c8y
+
+    # echo "Starting services using init.d scripts" >&2
+    # tedgectl start mosquitto
+    # sleep 1
+    # tedgectl start tedge-agent
+    # sleep 1
+    # tedgectl start tedge-mapper-c8y
+else
+    echo "WARNING: Could not start services as 'runsvdir' is not installed. You will need to start the services yourself" >&2
+fi
+
+
+
 if [ $# -gt 0 ]; then
     DEVICE_ID="$1"
 fi
@@ -28,6 +87,11 @@ if [ "$C8Y_AUTH_METHOD" = "basic" ] || [ "$C8Y_AUTH_METHOD" = "auto" ]; then
     fi
 fi
 
+post_bootstrap() {
+    MESSAGE=$(printf '{"text": "tedge started up 🚀 version=%s"}' "$(tedge --version | cut -d' ' -f2)")
+    tedge mqtt pub --qos 1 "te/device/main///e/startup" "$MESSAGE"
+}
+
 # Check if a certificate already exists
 if [ -z "$(tedge config get device.id 2>/dev/null)" ]; then
     if [ -z "$DEVICE_ID" ]; then
@@ -36,7 +100,7 @@ if [ -z "$(tedge config get device.id 2>/dev/null)" ]; then
     tedge cert create --device-id "$DEVICE_ID"
 fi
 
-# Show device certifcate
+# Show device certificate
 tedge cert show
 
 if [ -z "$(tedge config get c8y.url 2>/dev/null)" ]; then
@@ -70,44 +134,9 @@ if [ -z "$(tedge config get c8y.url 2>/dev/null)" ]; then
     tedge connect c8y
 fi
 
-#
-# Configure services if runit is installed
-#
-if command -V runsvdir >/dev/null 2>&1; then
-    if ! grep -q '^SVDIR=/.*' @CONFIG_DIR@/env; then
-        if [ -d /var/run ]; then
-            SVDIR=/var/run/services
-        elif [ -d /run ]; then
-            SVDIR=/run/services
-        elif [ -d /tmp ]; then
-            SVDIR=/tmp/services
-        else
-            echo "Could not find a volatile directory for the runit services" >&2
-            exit 1
-        fi
-        echo "SVDIR=$SVDIR" >> "@CONFIG_DIR@/env"
-        export SVDIR
-    fi
 
-    mkdir -p "$SVDIR"
-    tedgectl enable mosquitto
-    tedgectl enable tedge-agent
-    tedgectl enable tedge-mapper-c8y
-
-    # Start runit in the background
-    if ! pgrep -f "runsvdir -P $SVDIR" >/dev/null 2>&1; then
-        echo "Starting services using runit: runsvdir -P \"$SVDIR/\" &" >&2
-        runsvdir -P "$SVDIR/" &
-    else
-        echo "Services are already running via: runsvdir -P \"$SVDIR\""
-    fi
-
-    sleep 5
-    MESSAGE=$(printf '{"text": "tedge started up 🚀 version=%s"}' "$(tedge --version | cut -d' ' -f2)")
-    tedge mqtt pub --qos 1 "te/device/main///e/startup" "$MESSAGE"
-else
-    echo "WARNING: Could not start services as 'runsvdir' is not installed. You will need to start the services yourself" >&2
-fi
+sleep 5
+post_bootstrap
 
 # Show info to user about important connection settings
 DEVICE_ID="$(tedge config get device.id 2>/dev/null)"

--- a/src/tedge/services-init.d/S99mosquitto
+++ b/src/tedge/services-init.d/S99mosquitto
@@ -1,0 +1,161 @@
+#!/bin/sh
+#/etc/init.d/mosquitto: mosquitto is an MQTT broker which provides the back
+
+### BEGIN INIT INFO
+# Provides:          mosquitto
+# Short-Description: mosquitto MQTT broker
+# Required-Start:    $all
+# Required-Stop:     $all
+# Should-Start:      
+# Should-Stop:       
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+### END INIT INFO
+
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+
+set -e
+
+CONFIG_DIR="@CONFIG_DIR@"
+BIN=@CONFIG_DIR@/bin
+
+if [ -f "$CONFIG_DIR/env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$CONFIG_DIR/env"
+    set +a
+fi
+
+PATH=/bin:/usr/bin:/sbin:/usr/sbin:$BIN
+
+# For configuration of the init script use the file
+# /etc/default/mosquitto, do not edit this init script.
+
+# Set run_service to 1 to start mosquitto or 0 to disable it.
+run_service=1
+
+DAEMON="$BIN/mosquitto"
+DAEMON_ARGS="-c @CONFIG_DIR@/mosquitto.conf"
+DAEMON_USER="root"
+LOG_FILE=/var/log/mosquitto.log
+
+export TEDGE_RUN_LOCK_FILES="false"
+
+[ -e "/etc/default/mosquitto" ] && . "/etc/default/mosquitto"
+
+PIDFILE=/run/lock/mosquitto.lock
+if [ -d /run/lock ]; then
+    PIDFILE=/run/lock/mosquitto.lock
+else
+    PIDFILE=/var/run/mosquitto.lock
+fi
+
+STOP_RETRY_SCHEDULE='TERM/30/KILL/1'
+
+# Mock Debian helper functions when not being run on a debian based OS
+log_begin_msg() {
+    printf "%s" "$*"
+}
+
+log_end_msg() {
+    if [ "$1" = "0" ]; then
+        echo 'done'
+    else
+        echo 'error'
+    fi
+}
+
+log_daemon_msg() {
+    echo "$*"
+}
+
+log_progress_msg() {
+    echo "$*"
+}
+
+# TODO: Can the imports be excluded if the mocked functions are used above?
+if [ -f /lib/lsb/init-functions ]; then
+	# Debian based systems including WSL (ubuntu)
+	. /lib/lsb/init-functions
+fi
+
+if [ -f /etc/init.d/functions ]; then
+	# YOCTO
+	. /etc/init.d/functions
+fi
+
+do_start() {
+    if [ $run_service = 1 ]
+    then
+        log_begin_msg "Starting mosquitto daemon..."
+
+        # Create log file with given user so it can write to it (for non-root users)
+        touch "$LOG_FILE"
+        if [ -n "$DAEMON_USER" ]; then
+            chown "$DAEMON_USER" "$LOG_FILE"
+        fi
+
+        start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile "$PIDFILE" --chuid "${DAEMON_USER}" --user "${DAEMON_USER}" \
+                --startas /bin/sh -- -c "exec $DAEMON $DAEMON_ARGS >> '$LOG_FILE' 2>&1"
+        log_end_msg $?
+    fi
+}
+
+do_stop() {
+    if [ $run_service = 1 ]
+    then
+        log_begin_msg "Stopping mosquitto daemon..."
+
+        if start-stop-daemon --stop --quiet --oknodo --retry "$STOP_RETRY_SCHEDULE" --pidfile "${PIDFILE}" --user "${DAEMON_USER}"; then
+            log_end_msg 0
+            rm -f "${PIDFILE}"
+        else
+            log_end_msg 1
+        fi
+    fi
+}
+
+case "$1" in
+  start)
+    do_start
+    ;;
+
+  stop)
+    do_stop
+    ;;
+
+  restart)
+    do_stop
+    do_start
+    ;;
+
+  try-restart|force-reload)
+      if [ $run_service = 0 ]; then exit 0; fi
+    log_daemon_msg "Restarting mosquitto"
+    # force-reload is the same as reload or try-restart according
+    # to its definition, the reload is not implemented here, so
+    # force-reload is the alias of try-restart here, but it should
+    # be the alias of reload if reload is implemented.
+    #
+    # Only start the service when do_stop succeeds
+    do_stop && do_start
+    ;;
+
+  status)
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "mosquitto" && exit 0 || exit $?
+    elif command -V status >/dev/null 2>&1; then
+        status "${DAEMON}" && exit 0 || exit $?
+    else
+        pidof "$(dirname "${DAEMON}")" && exit 0 || exit $?
+    fi
+    ;;
+
+  *)
+    echo "Usage: /etc/init.d/mosquitto {start|stop|status|restart|try-restart|force-reload}" >&2
+    exit 1
+
+esac
+
+exit 0

--- a/src/tedge/services-init.d/S99tedge-agent
+++ b/src/tedge/services-init.d/S99tedge-agent
@@ -1,0 +1,163 @@
+#!/bin/sh
+#/etc/init.d/tedge-agent: tedge-agent is a thin-edge.io component to support operations
+
+### BEGIN INIT INFO
+# Provides:          tedge-agent
+# Short-Description: tedge-agent is a thin-edge.io component to support operations
+# Required-Start:    $all
+# Required-Stop:     $all
+# Should-Start:      
+# Should-Stop:       
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+### END INIT INFO
+
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+
+set -e
+
+CONFIG_DIR="@CONFIG_DIR@"
+BIN=@CONFIG_DIR@/bin
+
+if [ -f "$CONFIG_DIR/env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$CONFIG_DIR/env"
+    set +a
+fi
+
+PATH=/bin:/usr/bin:/sbin:/usr/sbin:$BIN
+
+# For configuration of the init script use the file
+# /etc/default/tedge-agent, do not edit this init script.
+
+# Set run_service to 1 to start tedge-agent or 0 to disable it.
+run_service=1
+
+# Run as root as sudo is not generally available
+DAEMON="$BIN/tedge-agent"
+DAEMON_ARGS=""
+DAEMON_USER="root"
+LOG_FILE=/var/log/tedge-agent.log
+
+export TEDGE_RUN_LOCK_FILES="false"
+
+[ -e "/etc/default/tedge-agent" ] && . "/etc/default/tedge-agent"
+
+PIDFILE=/run/lock/tedge-agent.lock
+if [ -d /run/lock ]; then
+    PIDFILE=/run/lock/tedge-agent.lock
+else
+    PIDFILE=/var/run/tedge-agent.lock
+fi
+
+STOP_RETRY_SCHEDULE='TERM/30/KILL/1'
+
+# Mock Debian helper functions when not being run on a debian based OS
+log_begin_msg() {
+    printf "%s" "$*"
+}
+
+log_end_msg() {
+    if [ "$1" = "0" ]; then
+        echo 'done'
+    else
+        echo 'error'
+    fi
+}
+
+log_daemon_msg() {
+    echo "$*"
+}
+
+log_progress_msg() {
+    echo "$*"
+}
+
+# TODO: Can the imports be excluded if the mocked functions are used above?
+if [ -f /lib/lsb/init-functions ]; then
+	# Debian based systems including WSL (ubuntu)
+	. /lib/lsb/init-functions
+fi
+
+if [ -f /etc/init.d/functions ]; then
+	# YOCTO
+	. /etc/init.d/functions
+fi
+
+do_start() {
+    if [ $run_service = 1 ]
+    then
+        log_begin_msg "Starting tedge-agent daemon..."
+        tedge init ||:
+
+        # Create log file with given user so it can write to it (for non-root users)
+        touch "$LOG_FILE"
+        if [ -n "$DAEMON_USER" ]; then
+            chown "$DAEMON_USER" "$LOG_FILE"
+        fi
+
+        start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile "$PIDFILE" --chuid "${DAEMON_USER}" --user "${DAEMON_USER}" \
+                --startas /bin/sh -- -c "exec $DAEMON $DAEMON_ARGS >> '$LOG_FILE' 2>&1"
+        log_end_msg $?
+    fi
+}
+
+do_stop() {
+    if [ $run_service = 1 ]
+    then
+        log_begin_msg "Stopping tedge-agent daemon..."
+
+        if start-stop-daemon --stop --quiet --oknodo --retry "$STOP_RETRY_SCHEDULE" --pidfile "${PIDFILE}" --user "${DAEMON_USER}"; then
+            log_end_msg 0
+            rm -f "${PIDFILE}"
+        else
+            log_end_msg 1
+        fi
+    fi
+}
+
+case "$1" in
+  start)
+    do_start
+    ;;
+
+  stop)
+    do_stop
+    ;;
+
+  restart)
+    do_stop
+    do_start
+    ;;
+
+  try-restart|force-reload)
+      if [ $run_service = 0 ]; then exit 0; fi
+    log_daemon_msg "Restarting tedge-agent"
+    # force-reload is the same as reload or try-restart according
+    # to its definition, the reload is not implemented here, so
+    # force-reload is the alias of try-restart here, but it should
+    # be the alias of reload if reload is implemented.
+    #
+    # Only start the service when do_stop succeeds
+    do_stop && do_start
+    ;;
+
+  status)
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-agent" && exit 0 || exit $?
+    elif command -V status >/dev/null 2>&1; then
+        status "${DAEMON}" && exit 0 || exit $?
+    else
+        pidof "$(dirname "${DAEMON}")" && exit 0 || exit $?
+    fi
+    ;;
+
+  *)
+    echo "Usage: /etc/init.d/tedge-agent {start|stop|status|restart|try-restart|force-reload}" >&2
+    exit 1
+
+esac
+
+exit 0

--- a/src/tedge/services-init.d/S99tedge-mapper-c8y
+++ b/src/tedge/services-init.d/S99tedge-mapper-c8y
@@ -1,0 +1,160 @@
+#!/bin/sh
+#/etc/init.d/tedge-mapper-c8y: tedge-mapper-c8y converts Thin Edge JSON measurements to Cumulocity JSON format
+
+### BEGIN INIT INFO
+# Provides:          tedge-mapper-c8y
+# Short-Description: tedge-mapper-c8y converts Thin Edge JSON measurements to Cumulocity JSON format
+# Required-Start:    $all
+# Required-Stop:     $all
+# Should-Start:      
+# Should-Stop:       
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+### END INIT INFO
+
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+
+set -e
+
+CONFIG_DIR="@CONFIG_DIR@"
+BIN=@CONFIG_DIR@/bin
+
+if [ -f "$CONFIG_DIR/env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$CONFIG_DIR/env"
+    set +a
+fi
+
+# For configuration of the init script use the file
+# /etc/default/tedge-mapper-c8y, do not edit this init script.
+
+# Set run_service to 1 to start tedge-mapper-c8y or 0 to disable it.
+run_service=1
+
+DAEMON="$BIN/tedge-mapper"
+DAEMON_ARGS="c8y"
+DAEMON_USER="root"
+LOG_FILE=/var/log/tedge-mapper-c8y.log
+
+export TEDGE_RUN_LOCK_FILES="false"
+
+[ -e "/etc/default/tedge-mapper-c8y" ] && . "/etc/default/tedge-mapper-c8y"
+
+PIDFILE=/run/lock/tedge-mapper-c8y.lock
+if [ -d /run/lock ]; then
+    PIDFILE=/run/lock/tedge-mapper-c8y.lock
+else
+    PIDFILE=/var/run/tedge-mapper-c8y.lock
+fi
+
+STOP_RETRY_SCHEDULE='TERM/30/KILL/1'
+
+# Mock Debian helper functions when not being run on a debian based OS
+log_begin_msg() {
+    printf "%s" "$*"
+}
+
+log_end_msg() {
+    if [ "$1" = "0" ]; then
+        echo 'done'
+    else
+        echo 'error'
+    fi
+}
+
+log_daemon_msg() {
+    echo "$*"
+}
+
+log_progress_msg() {
+    echo "$*"
+}
+
+# TODO: Can the imports be excluded if the mocked functions are used above?
+if [ -f /lib/lsb/init-functions ]; then
+	# Debian based systems including WSL (ubuntu)
+	. /lib/lsb/init-functions
+fi
+
+if [ -f /etc/init.d/functions ]; then
+	# YOCTO
+	. /etc/init.d/functions
+fi
+
+do_start() {
+    if [ $run_service = 1 ]
+    then
+        log_begin_msg "Starting tedge-mapper-c8y daemon..."
+        tedge init ||:
+
+        # Create log file with given user so it can write to it (for non-root users)
+        touch "$LOG_FILE"
+        if [ -n "$DAEMON_USER" ]; then
+            chown "$DAEMON_USER" "$LOG_FILE"
+        fi
+
+        start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile "$PIDFILE" --chuid "${DAEMON_USER}" --user "${DAEMON_USER}" \
+                --startas /bin/sh -- -c "exec $DAEMON $DAEMON_ARGS >> '$LOG_FILE' 2>&1"
+        log_end_msg $?
+    fi
+}
+
+do_stop() {
+    if [ $run_service = 1 ]
+    then
+        log_begin_msg "Stopping tedge-mapper-c8y daemon..."
+
+        if start-stop-daemon --stop --quiet --oknodo --retry "$STOP_RETRY_SCHEDULE" --pidfile "${PIDFILE}" --user "${DAEMON_USER}"; then
+            log_end_msg 0
+            rm -f "${PIDFILE}"
+        else
+            log_end_msg 1
+        fi
+    fi
+}
+
+case "$1" in
+  start)
+    do_start
+    ;;
+
+  stop)
+    do_stop
+    ;;
+
+  restart)
+    do_stop
+    do_start
+    ;;
+
+  try-restart|force-reload)
+      if [ $run_service = 0 ]; then exit 0; fi
+    log_daemon_msg "Restarting tedge-mapper-c8y"
+    # force-reload is the same as reload or try-restart according
+    # to its definition, the reload is not implemented here, so
+    # force-reload is the alias of try-restart here, but it should
+    # be the alias of reload if reload is implemented.
+    #
+    # Only start the service when do_stop succeeds
+    do_stop && do_start
+    ;;
+
+  status)
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "tedge-mapper-c8y" && exit 0 || exit $?
+    elif command -V status >/dev/null 2>&1; then
+        status "${DAEMON}" && exit 0 || exit $?
+    else
+        pidof "$(dirname "${DAEMON}")" && exit 0 || exit $?
+    fi
+    ;;
+
+  *)
+    echo "Usage: /etc/init.d/tedge-mapper-c8y {start|stop|status|restart|try-restart|force-reload}" >&2
+    exit 1
+
+esac
+
+exit 0

--- a/src/tedge/services-init.d/tedgectl
+++ b/src/tedge/services-init.d/tedgectl
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -e
+
+if [ -f @CONFIG_DIR@/env ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . @CONFIG_DIR@/env
+    set +a
+fi
+
+manage_initd() {
+    command="$1"
+    name="$2"
+
+    # check for non-service related actions first
+    case "$command" in
+        restart_device)
+            sync; sync;
+            sleep 2;
+            reboot;
+            exit 0
+            ;;
+    esac
+
+    SOURCE_SCRIPT=$(find "@CONFIG_DIR@/services-init.d" -name "*$name" | head -n1)
+    SERVICE_SCRIPT=$(find /etc/init.d -name "*$name" | head -n1)
+
+    case "$command" in
+        is_available)
+            exit 0
+            ;;
+        start) "$SERVICE_SCRIPT" start ;;
+        stop) "$SERVICE_SCRIPT" stop ;;
+        restart) "$SERVICE_SCRIPT" restart ;;
+        enable)
+            ln -sf "$SOURCE_SCRIPT" "$SERVICE_SCRIPT"
+            ;;
+        disable)
+            rm -f "$SERVICE_SCRIPT"
+            ;;
+        is_active|status)
+            "$SERVICE_SCRIPT" status
+            ;;
+        *) echo "Unsupported command. command=$command"; exit 1 ;;
+    esac
+}
+
+##############################
+# Main
+##############################
+COMMAND="$1"
+SERVICE_NAME=""
+if [ $# -ge 2 ]; then
+    SERVICE_NAME="$2"
+fi
+manage_initd "$COMMAND" "$SERVICE_NAME"


### PR DESCRIPTION
Add support for deploying the tedge-standalone package to Luckfox Pico devices (which are busybox based devices).

SysvInit service definitions are used due to runit not being included in the base image which is provided by Luckfox.