### PR TITLE
docs: add luckfox notes about loading the tedge shell environment

### DIFF
--- a/docs/Luckfox.md
+++ b/docs/Luckfox.md
@@ -50,3 +50,16 @@ Install thin-edge.io standalone on a Luckfox Pico device using the following ste
     ```sh
     /opt/tedge/bootstrap.sh
     ```
+
+5. Add the following shell profile snippet to enable loading of the tedge configuration by default in newly opened shells. You will need to reload your shell afterwards for it to take effect
+
+    ```sh
+    vi /etc/profile.d/tedge.sh
+    ```
+
+    ```sh
+    load_tedge_env() {
+        set -a; . /opt/tedge/env; set +a;
+    }
+    load_tedge_env
+    ```


### PR DESCRIPTION
Instruct users to add the shell snippet which is loaded when users open a new shell so that the tedg environment variables can be loaded automatically in interactive shells.