### PR TITLE
feat: add bootstrapping options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ src/tedge/bin/tedge
 tmp/
 /tedge-*
 binaries/zig-mosquitto/
+log.html
+output.xml
+report.html

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,9 @@
+{
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python3",
+    "robot.language-server.python": "${workspaceFolder}/.venv/bin/python3",
+    "robot.python.executable": "${workspaceFolder}/.venv/bin/python3",
+    "robot.pythonpath": [
+        "${workspaceFolder}/tests/RobotFramework/.venv/bin/python3"
+    ],
+    "python.envFile": "${workspaceFolder}/.env"
+}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/i
 curl -fsSL https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data
 ```
 
-Then, follow the instructions printed out on the console to bootstrap (configure) and then start the services. However if you are planning on using Cumulocity's basic authentication, then you need to run the following section before running the `bootstrap.sh` script.
+Then, follow the instructions printed out on the console to bootstrap (configure) and then start the services.
 
 ### Install without wget/curl
 
@@ -66,11 +66,24 @@ Before running the `bootstrap.sh` script, you will need to set the device's cred
 For example, if you installed thin-edge.io under `/data` then you can set the credentials using the following snippet:
 
 ```sh
-cat <<EOT > /data/tedge/credentials.toml
+./bootstrap.sh --device-user "{tenant}/device_{external_id}" --device-password "{password}" --c8y-url {CumulocityURL}
+
+# example
+./bootstrap.sh --device-user "t12345/device_tedge-abcdef" --device-password 'ex4amp!3' --c8y-url example.cumulocity.com
+```
+
+Alternative, you can set the `credentials.toml` under the installed directory, e.g. `/data/tedge/credentials.toml` (if you're using the default installation directory):
+
+```sh
 [c8y]
 username = "{tenant}/device_{external_id}"
 password = "{password}"
-EOT
+```
+
+For [go-c8y-cli](https://goc8ycli.netlify.app/) users, you can register a device and generate randomized credentials using the following command. The device's username (including tenant) and password will be printed out on the console, and then you can provide the values to the `bootstrap.sh` script. 
+
+```sh
+c8y deviceregistration register-basic --id tedge-abcdef
 ```
 
 ## Automatically starting services

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Assuming you have already launched the custom `runsvdir` instance, the following
 Before running any of the command you need to load the environment variables using the following one-liner:
 
 ```sh
-set -a; . /data/tedge/env; set +a
+. /data/tedge/env
 ```
 
 ### Start services

--- a/docs/Luckfox.md
+++ b/docs/Luckfox.md
@@ -59,7 +59,7 @@ Install thin-edge.io standalone on a Luckfox Pico device using the following ste
 
     ```sh
     load_tedge_env() {
-        set -a; . /opt/tedge/env; set +a;
+        . /opt/tedge/env;
     }
     load_tedge_env
     ```

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ EXAMPLE
     # Install under a custom location but install the non-upx'd versions
 
     $0 --install-path /home/etc --overwrite
-    # Install under a custom location and overrite any existing configuration files
+    # Install under a custom location and overwrite any existing configuration files
 
     $0 --file ./tedge-standalone-arm64.tar.gz --install-path /home/root
     # Install from a manually downloaded file and install under a custom path

--- a/install.sh
+++ b/install.sh
@@ -187,7 +187,7 @@ main() {
     echo
     echo Import the shell environment using:
     echo
-    echo "    set -a; . '$INSTALL_PATH/tedge/env'; set +a"
+    echo "    . '$INSTALL_PATH/tedge/env'"
     echo
 }
 

--- a/install.sh
+++ b/install.sh
@@ -183,7 +183,22 @@ main() {
     echo
     echo "Configure and start thin-edge.io using the following command:"
     echo
-    echo "    $INSTALL_PATH/tedge/bootstrap.sh"
+    echo Option 1: Register using Cumulocity Certificate Authority
+    echo
+    echo "    $INSTALL_PATH/tedge/bootstrap.sh --ca c8y --c8y-url 'example.cumulocity.com'"
+    echo
+    echo "    $INSTALL_PATH/tedge/bootstrap.sh --ca c8y --c8y-url 'example.cumulocity.com' --device-id tedge01"
+    echo
+    echo
+    echo Option 2: Register using Cumulocity self-signed certificate
+    echo
+    echo "    $INSTALL_PATH/tedge/bootstrap.sh --ca c8y --c8y-url 'example.cumulocity.com' --device-id tedge01"
+    echo
+    echo
+    echo "Option 3: Register using Cumulocity Basic Authorization Credentials (pre-registered)"
+    echo
+    echo "    $INSTALL_PATH/tedge/bootstrap.sh --c8y-url 'example.cumulocity.com' --device-user 't12345/device_tedge01' --device-password 'ex4ampl3['"
+    echo
     echo
     echo Import the shell environment using:
     echo

--- a/justfile
+++ b/justfile
@@ -4,3 +4,17 @@ PACKAGE := "tedge-standalone"
 # Build static binaries and create the tarball package
 build target target_name *args:
     ./scripts/build.sh --target {{target}} --target-name {{target_name}} --package {{PACKAGE}} {{args}}
+
+# Build artifacts to be used in system tests
+build-test:
+    just build aarch64-linux-musl arm64-noupx --skip-upx
+    just build aarch64-linux-musl arm64
+
+# Install python virtual environment
+venv:
+  [ -d .venv ] || python3 -m venv .venv
+  ./.venv/bin/pip3 install -r tests/requirements.txt
+
+# Run tests
+test *args='':
+  ./.venv/bin/python3 -m robot.run --outputdir output {{args}} tests

--- a/src/tedge/bin/tedgectl
+++ b/src/tedge/bin/tedgectl
@@ -18,9 +18,17 @@ manage_runit() {
             # Check if runit instance is active
             pgrep -f "runsvdir -P $SVDIR" >/dev/null 2>&1
             ;;
-        start) sv start "$name" ;;
-        stop) sv stop "$name" ;;
-        restart) sv restart "$name" ;;
+        start)
+            manage_runit enable "$name" ||:
+            sv start "$name" ||:
+            ;;
+        stop)
+            sv stop "$name" ||:
+            ;;
+        restart)
+            manage_runit enable "$name" ||:
+            sv restart "$name" ||:
+            ;;
         enable)
             if [ ! -d "$SVDIR/$name" ]; then
                 ln -s "$RUNIT_SRCDIR/$name" "$SVDIR/"

--- a/src/tedge/bin/tedgectl
+++ b/src/tedge/bin/tedgectl
@@ -5,10 +5,8 @@ export SVDIR="${SVDIR:-/run/services}"
 export RUNIT_SRCDIR="${RUNIT_SRCDIR:-@CONFIG_DIR@/services}"
 
 if [ -f @CONFIG_DIR@/env ]; then
-    set -a
     # shellcheck disable=SC1091
     . @CONFIG_DIR@/env
-    set +a
 fi
 
 manage_runit() {

--- a/src/tedge/bootstrap.sh
+++ b/src/tedge/bootstrap.sh
@@ -17,7 +17,7 @@ if command -V runsvdir >/dev/null 2>&1; then
     #
     # Setup runit services
     #
-    if ! grep -q '^SVDIR=/.*' @CONFIG_DIR@/env; then
+    if ! grep -q '^export SVDIR=/.*' "$CONFIG_DIR/env"; then
         if [ -d /var/run ]; then
             SVDIR=/var/run/services
         elif [ -d /run ]; then
@@ -28,7 +28,7 @@ if command -V runsvdir >/dev/null 2>&1; then
             echo "Could not find a volatile directory for the runit services" >&2
             exit 1
         fi
-        echo "SVDIR=$SVDIR" >> "@CONFIG_DIR@/env"
+        echo "export SVDIR=$SVDIR" >> "$CONFIG_DIR/env"
         export SVDIR
     fi
 

--- a/src/tedge/bootstrap.sh
+++ b/src/tedge/bootstrap.sh
@@ -1,10 +1,102 @@
 #!/bin/sh
 set -e
-if [ -f @CONFIG_DIR@/env ]; then
-    set -a
+CONFIG_DIR="@CONFIG_DIR@"
+
+CA=${CA:-c8y}
+C8Y_URL="${C8Y_URL:-}"
+DEVICE_ID="${DEVICE_ID:-}"
+DEVICE_USER="${DEVICE_USER:-}"
+DEVICE_PASSWORD="${DEVICE_PASSWORD:-}"
+DEVICE_ONE_TIME_PASSWORD="${DEVICE_ONE_TIME_PASSWORD:-}"
+
+usage() {
+    cat << EOT
+Install thin-edge.io standalone package for running on resource constrained devices
+without any accessible init system.
+
+USAGE
+    $0 [--install-path <path>] [--version <version>] [--no-upx]
+
+ARGUMENTS
+  --c8y-url <url>               Cumulocity URL
+  --device-user <name>          Device tenant and username, e.g. t12345/device_tedge01 (Used in Basic Auth mode only).
+                                Note: The device-id will be derived from the device user
+  --device-password <path>      Device user name (Used in Basic Auth mode only)
+  --device-id <name>            Device ID (Cumulocity External ID). tedge-identity will be used if the value is not provided
+  --ca <type>                   Certificate Authority Type, e.g. c8y or self-signed. Defaults to c8y (when basic auth is not being used)
+
+NOTES:
+
+* If mandatory values are not provided, then the script will prompt you for the values. However you can pre-configure all of the settings
+  yourself by adding the required settings to the tedge.toml file, and if you're using Basic Auth, then the credentials can also be set
+  in the credentials.toml file.
+
+EXAMPLE
+
+    $0 --help
+    # Display the bootstrapping options
+
+    $0 --c8y-url example.cumulocity.com --device-user "t12345/tedge01" --device-password "ex4ampl3["
+    # Bootstrap device using Cumulocity Basic Auth credentials
+
+    $0 --c8y-url example.cumulocity.com --ca c8y --one-time-password "ex4ampl3["
+    # Bootstrap device using Cumulocity Certificate Authority (in PUBLIC_PREVIEW)
+
+    $0 --c8y-url example.cumulocity.com --ca self-signed
+    # Bootstrap device using a self signed certificate. This will required you to enter your Cumulocity
+    # User's credentials and the Tenant Manager Role
+EOT
+}
+
+REST_ARGS=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --device-id)
+            DEVICE_ID="$2"
+            shift
+            ;;
+        --c8y-url)
+            C8Y_URL="$2"
+            shift
+            ;;
+        --ca)
+            CA="$2"
+            shift
+            ;;
+        --device-user)
+            DEVICE_USER="$2"
+            shift
+            ;;
+        --device-password)
+            DEVICE_PASSWORD="$2"
+            shift
+            ;;
+        --one-time-password)
+            DEVICE_ONE_TIME_PASSWORD="$2"
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --*|-*)
+            echo "Unknown flags. $1" >&2
+            exit 1
+            ;;
+        *)
+            REST_ARGS="$REST_ARGS $1"
+            ;;
+    esac
+    shift
+done
+
+# shellcheck disable=SC2086
+set -- $REST_ARGS
+
+if [ -f "$CONFIG_DIR/env" ]; then
     # shellcheck disable=SC1091
-    . @CONFIG_DIR@/env
-    set +a
+    . "$CONFIG_DIR/env"
 fi
 
 # Init (also creating the multi-call binary symlinks)
@@ -41,97 +133,162 @@ if command -V runsvdir >/dev/null 2>&1; then
     else
         echo "Services are already running via: runsvdir -P \"$SVDIR\""
     fi
+
+    # Note: proactively enable mosquitto otherwise the tedge connect can require
+    # a few attempts before it can connect, and sometimes it will fail even after 3 attempts
+    echo "Enabling mosquitto by default" >&2
+    tedgectl enable mosquitto
+
 elif [ -d /etc/init.d ]; then
     #
     # Setup SysVInit services
     #
     echo "Using /etc/init.d service definitions" >&2
-    cp "@CONFIG_DIR@/services-init.d"/S[0-9][0-9]* /etc/init.d/
-    rm -f "@CONFIG_DIR@/bin/tedgectl"
-    ln -s "@CONFIG_DIR@/services-init.d/tedgectl" "@CONFIG_DIR@/bin/tedgectl"
+    cp "$CONFIG_DIR/services-init.d"/S[0-9][0-9]* /etc/init.d/
+    rm -f "$CONFIG_DIR/bin/tedgectl"
+    ln -s "$CONFIG_DIR/services-init.d/tedgectl" "$CONFIG_DIR/bin/tedgectl"
+
+    # Note: proactively enable mosquitto otherwise the tedge connect can require
+    # a few attempts before it can connect, and sometimes it will fail even after 3 attempts
+    echo "Enabling mosquitto by default" >&2
+    tedgectl enable mosquitto
 else
     echo "WARNING: Could not start services as 'runsvdir' is not installed. You will need to start the services yourself" >&2
 fi
 
 
+C8Y_AUTH_METHOD=certificate
+C8Y_CREDENTIALS_PATH=$(tedge config get c8y.credentials_path 2>/dev/null ||:)
 
-if [ $# -gt 0 ]; then
-    DEVICE_ID="$1"
+if [ -n "$DEVICE_USER" ] && [ -n "$DEVICE_PASSWORD" ]; then
+    # infer device id from basic auth credentials
+    C8Y_AUTH_METHOD=basic
+    DEVICE_ID=$(echo "$DEVICE_USER" | cut -d/ -f2- | sed 's|^device_||')
+
+    echo "Writing device's basic auth credentials to file: $C8Y_CREDENTIALS_PATH" >&2
+    cat <<EOT > "$C8Y_CREDENTIALS_PATH"
+[c8y]
+username = "$DEVICE_USER"
+password = "$DEVICE_PASSWORD"
+EOT
+elif [ -f "$C8Y_CREDENTIALS_PATH" ]; then
+    # infer device id from basic auth credentials
+    C8Y_AUTH_METHOD=basic
+    DEVICE_ID=$(grep username "$C8Y_CREDENTIALS_PATH" | sed 's/username *= *"\(.*\)"/\1/' | cut -d/ -f2- | sed 's|^device_||')
+else
+    C8Y_AUTH_METHOD=certificate
 fi
 
-#
-# Detect authentication, get device.id from the credentials file
-#
-C8Y_AUTH_METHOD=$(tedge config get c8y.auth_method ||:)
-C8Y_CREDENTIALS_PATH=$(tedge config get c8y.credentials_path ||:)
-NEEDS_CERT_UPLOAD=1
-if [ "$C8Y_AUTH_METHOD" = "basic" ] || [ "$C8Y_AUTH_METHOD" = "auto" ]; then
-    if [ -f "$C8Y_CREDENTIALS_PATH" ]; then
-        DEVICE_ID=$(grep username "$C8Y_CREDENTIALS_PATH" | sed 's/username *= *"\(.*\)"/\1/' | cut -d/ -f2- | sed 's|^device_||')
-        echo "Using c8y.credentials_path as authentication. device.id=$DEVICE_ID" >&2
-        NEEDS_CERT_UPLOAD=0
+tedge config set c8y.auth_method "$C8Y_AUTH_METHOD"
+
+if [ -z "$DEVICE_ID" ]; then
+    echo "Using tedge-identity to detect the device.id"
+    DEVICE_ID=$("$CONFIG_DIR/bin/tedge-identity" 2>/dev/null)
+fi
+
+if [ -n "$DEVICE_ID" ]; then
+    tedge config set device.id "$DEVICE_ID"
+fi
+
+configure_c8y_url() {
+    if [ -z "$(tedge config get c8y.url 2>/dev/null)" ]; then
+        if [ -z "$C8Y_URL" ]; then
+            printf "Enter c8y.url: "
+            read -r C8Y_URL
+        fi
+
+        C8Y_URL=$(echo "$C8Y_URL" | sed -E 's|^https?://||g')
+        echo "Setting c8y.url to $C8Y_URL"
+        tedge config set c8y.url "$C8Y_URL"
     fi
-fi
+}
+
+configure_self_signed_certificate() {
+    # Check if a certificate already exists
+    DEVICE_CERT_PATH=$(tedge config get device.cert_path 2>/dev/null ||:)
+
+    if [ ! -f "$DEVICE_CERT_PATH" ]; then
+        tedge cert create --device-id "$DEVICE_ID"
+        # Note: If the user is blank, tedge will prompt for the required information
+        tedge cert upload c8y --user "$C8Y_USER"
+    else
+        # Show device certificate
+        tedge cert show
+    fi
+}
+
+configure_c8y_ca_certificate() {
+    DEVICE_CERT_PATH=$(tedge config get device.cert_path 2>/dev/null ||:)
+
+    if [ -f "$DEVICE_CERT_PATH" ]; then
+        echo "Device certificate already exists" >&2
+        return 0
+    fi
+
+    GENERATE_ONE_TIME_PASSWORD=1
+    if [ "$GENERATE_ONE_TIME_PASSWORD" = 1 ] && [ -z "$DEVICE_ONE_TIME_PASSWORD" ] && [ -n "$DEVICE_ID" ]; then
+        DEVICE_ONE_TIME_PASSWORD=$(printf "%s" "$DEVICE_ID" | md5sum | awk '{print $1}')
+    fi
+
+    C8Y_HOST=$(tedge config get c8y.url 2>/dev/null ||:)
+    if [ -n "$C8Y_HOST" ]; then
+        echo "Cumulocity Registration URL"
+        echo
+        echo "  Cumulocity:  https://$C8Y_HOST/apps/devicemanagement/index.html#/deviceregistration?externalId=$DEVICE_ID&one-time-password=$DEVICE_ONE_TIME_PASSWORD"
+        echo
+    fi
+
+    tedge cert download c8y --device-id "$DEVICE_ID" --one-time-password "$DEVICE_ONE_TIME_PASSWORD" --retry-every 5s --max-timeout 300s
+}
+
+connect_c8y() {
+    if [ -n "$(tedge config get c8y.url 2>/dev/null)" ]; then
+        tedge reconnect c8y
+    fi
+}
 
 post_bootstrap() {
     MESSAGE=$(printf '{"text": "tedge started up 🚀 version=%s"}' "$(tedge --version | cut -d' ' -f2)")
     tedge mqtt pub --qos 1 "te/device/main///e/startup" "$MESSAGE"
 }
 
-# Check if a certificate already exists
-if [ -z "$(tedge config get device.id 2>/dev/null)" ]; then
-    if [ -z "$DEVICE_ID" ]; then
-        DEVICE_ID=$(@CONFIG_DIR@/bin/tedge-identity 2>/dev/null)
-    fi
-    tedge cert create --device-id "$DEVICE_ID"
-fi
+#
+# Configure
+#
+configure_c8y_url
 
-# Show device certificate
-tedge cert show
+case "$C8Y_AUTH_METHOD" in
+    certificate)
+        case "$CA" in
+            self-signed)
+                configure_self_signed_certificate
+                ;;
+            c8y)
+                configure_c8y_ca_certificate
+                ;;
+            *)
+                echo "ERROR: Unknown certificate authority option. value=$CA. Available options: [self-signed, ca]" >&2
+                exit 1
+                ;;
+        esac
+        ;;
+esac
 
-if [ -z "$(tedge config get c8y.url 2>/dev/null)" ]; then
-    if [ -z "$C8Y_URL" ]; then
-        printf "Enter c8y.url: "
-        read -r C8Y_URL
-    fi
-
-    C8Y_AUTH_METHOD=$(tedge config get c8y.auth_method ||:)
-    C8Y_CREDENTIALS_PATH=$(tedge config get c8y.credentials_path ||:)
-    NEEDS_CERT_UPLOAD=1
-    if [ "$C8Y_AUTH_METHOD" = "basic" ] || [ "$C8Y_AUTH_METHOD" = "auto" ]; then
-        if [ -f "$C8Y_CREDENTIALS_PATH" ]; then
-            echo "Using c8y.credentials_path as authentication" >&2
-            NEEDS_CERT_UPLOAD=0
-        fi
-    fi
-
-    C8Y_URL=$(echo "$C8Y_URL" | sed 's|^https?://||g')
-    echo "Setting c8y.url to $C8Y_URL"
-    tedge config set c8y.url "$C8Y_URL"
-
-    if [ "$NEEDS_CERT_UPLOAD" = 1 ]; then
-        if [ -z "$C8Y_USER" ]; then
-            printf "Enter your c8y username: "
-            read -r C8Y_USER
-        fi
-        tedge cert upload c8y --user "$C8Y_USER"
-    fi
-
-    tedge connect c8y
-fi
-
+connect_c8y
 
 sleep 5
 post_bootstrap
 
 # Show info to user about important connection settings
-DEVICE_ID="$(tedge config get device.id 2>/dev/null)"
-C8Y_URL="$(tedge config get c8y.url 2>/dev/null)"
+DEVICE_ID="$(tedge config get device.id 2>/dev/null ||:)"
+C8Y_URL="$(tedge config get c8y.url 2>/dev/null ||:)"
 echo
 echo "--------------------------- Summary ---------------------------"
 echo "thin-edge.io"
-echo "  device.id:      $DEVICE_ID"
-echo "  c8y.url:        $C8Y_URL"
-echo "  Cumulocity IoT: https://${C8Y_URL}/apps/devicemanagement/index.html#/assetsearch?filter=*${DEVICE_ID}*"
+echo "  device.id:      ${DEVICE_ID:-not configured}"
+echo "  c8y.url:        ${C8Y_URL:-not configured}"
+if [ -n "$DEVICE_ID" ] && [ -n "$C8Y_URL" ]; then
+    echo "  Cumulocity IoT: https://${C8Y_URL}/apps/devicemanagement/index.html#/assetsearch?filter=*${DEVICE_ID}*"
+fi
 echo "---------------------------------------------------------------"
 echo

--- a/src/tedge/env.default
+++ b/src/tedge/env.default
@@ -1,10 +1,10 @@
-SSL_CERT_FILE=@CONFIG_DIR@/ca-certificates.crt
+export SSL_CERT_FILE=@CONFIG_DIR@/ca-certificates.crt
 # SVDIR is set via the bootstrap.sh script as it should be set to a volatile location
 # which usually differs across different environments
-#SVDIR=/run/services
-RUNIT_SRCDIR=@CONFIG_DIR@/services
-TEDGE_CONFIG_DIR=@CONFIG_DIR@
-PATH=@CONFIG_DIR@/bin:/sbin:/bin:/usr/sbin:/usr/bin
+#export SVDIR=/run/services
+export RUNIT_SRCDIR=@CONFIG_DIR@/services
+export TEDGE_CONFIG_DIR=@CONFIG_DIR@
+export PATH=@CONFIG_DIR@/bin:/sbin:/bin:/usr/sbin:/usr/bin
 
 # archive sm-plugin config
-# ARCHIVE_ROOT_DIR=/data
+# export ARCHIVE_ROOT_DIR=/data

--- a/src/tedge/services-init.d/S99mosquitto
+++ b/src/tedge/services-init.d/S99mosquitto
@@ -21,10 +21,8 @@ CONFIG_DIR="@CONFIG_DIR@"
 BIN=@CONFIG_DIR@/bin
 
 if [ -f "$CONFIG_DIR/env" ]; then
-    set -a
     # shellcheck disable=SC1091
     . "$CONFIG_DIR/env"
-    set +a
 fi
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin:$BIN

--- a/src/tedge/services-init.d/S99tedge-agent
+++ b/src/tedge/services-init.d/S99tedge-agent
@@ -21,10 +21,8 @@ CONFIG_DIR="@CONFIG_DIR@"
 BIN=@CONFIG_DIR@/bin
 
 if [ -f "$CONFIG_DIR/env" ]; then
-    set -a
     # shellcheck disable=SC1091
     . "$CONFIG_DIR/env"
-    set +a
 fi
 
 PATH=/bin:/usr/bin:/sbin:/usr/sbin:$BIN

--- a/src/tedge/services-init.d/S99tedge-mapper-c8y
+++ b/src/tedge/services-init.d/S99tedge-mapper-c8y
@@ -21,10 +21,8 @@ CONFIG_DIR="@CONFIG_DIR@"
 BIN=@CONFIG_DIR@/bin
 
 if [ -f "$CONFIG_DIR/env" ]; then
-    set -a
     # shellcheck disable=SC1091
     . "$CONFIG_DIR/env"
-    set +a
 fi
 
 # For configuration of the init script use the file

--- a/src/tedge/services-init.d/tedgectl
+++ b/src/tedge/services-init.d/tedgectl
@@ -4,10 +4,8 @@ set -e
 CONFIG_DIR="@CONFIG_DIR@"
 
 if [ -f "$CONFIG_DIR/env" ]; then
-    set -a
     # shellcheck disable=SC1091
     . "$CONFIG_DIR/env"
-    set +a
 fi
 
 manage_initd() {

--- a/src/tedge/services/mosquitto/run
+++ b/src/tedge/services/mosquitto/run
@@ -13,10 +13,8 @@ BIN="@CONFIG_DIR@/bin"
 CONFIG_DIR="@CONFIG_DIR@"
 
 if [ -f "$CONFIG_DIR/env" ]; then
-    set -a
     # shellcheck disable=SC1091
     . "$CONFIG_DIR/env"
-    set +a
 fi
 
 mkdir -p "$LOCK_DIR"

--- a/src/tedge/services/tedge-agent/run
+++ b/src/tedge/services/tedge-agent/run
@@ -13,10 +13,8 @@ BIN="@CONFIG_DIR@/bin"
 CONFIG_DIR="@CONFIG_DIR@"
 
 if [ -f "$CONFIG_DIR/env" ]; then
-    set -a
     # shellcheck disable=SC1091
     . "$CONFIG_DIR/env"
-    set +a
 fi
 
 mkdir -p "$LOCK_DIR"

--- a/src/tedge/services/tedge-mapper-aws/run
+++ b/src/tedge/services/tedge-mapper-aws/run
@@ -13,10 +13,8 @@ BIN="@CONFIG_DIR@/bin"
 CONFIG_DIR="@CONFIG_DIR@"
 
 if [ -f "$CONFIG_DIR/env" ]; then
-    set -a
     # shellcheck disable=SC1091
     . "$CONFIG_DIR/env"
-    set +a
 fi
 
 mkdir -p "$LOCK_DIR"

--- a/src/tedge/services/tedge-mapper-az/run
+++ b/src/tedge/services/tedge-mapper-az/run
@@ -13,10 +13,8 @@ BIN="@CONFIG_DIR@/bin"
 CONFIG_DIR="@CONFIG_DIR@"
 
 if [ -f "$CONFIG_DIR/env" ]; then
-    set -a
     # shellcheck disable=SC1091
     . "$CONFIG_DIR/env"
-    set +a
 fi
 
 mkdir -p "$LOCK_DIR"

--- a/src/tedge/services/tedge-mapper-c8y/run
+++ b/src/tedge/services/tedge-mapper-c8y/run
@@ -13,10 +13,8 @@ BIN="@CONFIG_DIR@/bin"
 CONFIG_DIR="@CONFIG_DIR@"
 
 if [ -f "$CONFIG_DIR/env" ]; then
-    set -a
     # shellcheck disable=SC1091
     . "$CONFIG_DIR/env"
-    set +a
 fi
 
 mkdir -p "$LOCK_DIR"

--- a/src/tedge/sm-plugins/executable
+++ b/src/tedge/sm-plugins/executable
@@ -1,10 +1,8 @@
 #!/bin/sh
 set -e
 if [ -f @CONFIG_DIR@/env ]; then
-    set -a
     # shellcheck disable=SC1091
     . @CONFIG_DIR@/env
-    set +a
 fi
 
 EXIT_OK=0

--- a/src/tedge/stop.sh
+++ b/src/tedge/stop.sh
@@ -2,10 +2,8 @@
 set -e
 
 if [ -f @CONFIG_DIR@/env ]; then
-    set -a
     # shellcheck disable=SC1091
     . @CONFIG_DIR@/env
-    set +a
 fi
 
 tedgectl stop tedge-mapper-c8y

--- a/tests/installation_runit_using_c8y_basic_auth.robot
+++ b/tests/installation_runit_using_c8y_basic_auth.robot
@@ -1,0 +1,45 @@
+*** Settings ***
+Resource            ./resources/common.resource
+Library    Cumulocity
+Library    DeviceLibrary
+
+Test Teardown    Stop Device
+
+*** Test Cases ***
+
+Install From File With UPX
+    ${file}=    Set Variable    tedge-standalone-arm64.tar.gz
+    Setup Device With Binaries    image=busybox   file=${file}    target_dir=/root
+    Install Standalone Binary    ${file}    target_dir=/root
+    Bootstrap Using Basic Authentication
+
+Install From File Without UPX
+    ${file}=    Set Variable    tedge-standalone-arm64-noupx.tar.gz
+    Setup Device With Binaries    image=busybox   file=${file}    target_dir=/root
+    Install Standalone Binary    ${file}    target_dir=/root
+    Bootstrap Using Basic Authentication
+
+Install From URL With UPX
+    Skip    TODO
+    Setup Device    image=busybox
+    DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data
+    Bootstrap Using Basic Authentication
+
+Install From URL Without UPX
+    Skip    TODO
+    Setup Device    image=busybox
+    DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data --no-upx
+    Bootstrap Using Basic Authentication
+
+
+*** Keywords ***
+
+Bootstrap Using Basic Authentication
+    [Arguments]    ${install_path}=/data
+
+    ${credentials}=    Cumulocity.Bulk Register Device With Basic Auth       external_id=${DEVICE_ID}
+    ${c8y_domain}=    Cumulocity.Get Domain
+    DeviceLibrary.Execute Command    cmd=${install_path}/tedge/bootstrap.sh --c8y-url '${c8y_domain}' --device-user ${credentials.username} --device-password '${credentials.password}'
+    
+    Cumulocity.Device Should Exist    ${DEVICE_ID}
+    Cumulocity.Device Should Have Event/s    expected_text=tedge started up.*    type=startup

--- a/tests/installation_runit_using_c8y_ca.robot
+++ b/tests/installation_runit_using_c8y_ca.robot
@@ -1,0 +1,51 @@
+*** Settings ***
+Resource            ./resources/common.resource
+Library    Cumulocity
+Library    DeviceLibrary
+
+Test Teardown    Stop Device
+
+*** Test Cases ***
+
+Install From File With UPX
+    ${file}=    Set Variable    tedge-standalone-arm64.tar.gz
+    Setup Device With Binaries    image=busybox   file=${file}    target_dir=/root
+    Install Standalone Binary    ${file}    target_dir=/root
+    Bootstrap Using Certificate Authority
+
+Install From File Without UPX
+    ${file}=    Set Variable    tedge-standalone-arm64-noupx.tar.gz
+    Setup Device With Binaries    image=busybox   file=${file}    target_dir=/root
+    Install Standalone Binary    ${file}    target_dir=/root
+    Bootstrap Using Certificate Authority
+
+Install From URL With UPX
+    Skip    TODO
+    Setup Device    image=busybox
+    DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data
+    Bootstrap Using Certificate Authority
+
+Install From URL Without UPX
+    Skip    TODO
+    Setup Device    image=busybox
+    DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data --no-upx
+    Bootstrap Using Certificate Authority
+
+
+Install on SysVInit Device
+    ${file}=    Set Variable    tedge-standalone-arm64-noupx.tar.gz
+    Setup SysVInit Device With Binaries    image=debian:12   file=${file}    target_dir=/root
+    Install Standalone Binary    ${file}    target_dir=/root
+    Bootstrap Using Certificate Authority
+
+*** Keywords ***
+
+Bootstrap Using Certificate Authority
+    [Arguments]    ${install_path}=/data
+
+    ${credentials}=    Cumulocity.Bulk Register Device With Cumulocity CA       external_id=${DEVICE_ID}
+    ${c8y_domain}=    Cumulocity.Get Domain
+    DeviceLibrary.Execute Command    cmd=/data/tedge/bootstrap.sh --c8y-url '${c8y_domain}' --ca c8y --device-id '${DEVICE_ID}' --one-time-password '${credentials.one_time_password}'
+    
+    Cumulocity.Device Should Exist    ${DEVICE_ID}
+    Cumulocity.Device Should Have Event/s    expected_text=tedge started up.*    type=startup

--- a/tests/installation_runit_using_c8y_self_signed.robot
+++ b/tests/installation_runit_using_c8y_self_signed.robot
@@ -1,0 +1,44 @@
+*** Settings ***
+Resource            ./resources/common.resource
+Library    Cumulocity
+Library    DeviceLibrary
+
+Test Teardown    Stop Device
+
+*** Test Cases ***
+
+Install From File With UPX
+    ${file}=    Set Variable    tedge-standalone-arm64.tar.gz
+    Setup Device With Binaries    image=busybox   file=${file}    target_dir=/root
+    Install Standalone Binary    ${file}    target_dir=/root
+    Bootstrap Using Self-Signed Certificate
+
+Install From File Without UPX
+    ${file}=    Set Variable    tedge-standalone-arm64-noupx.tar.gz
+    Setup Device With Binaries    image=busybox   file=${file}    target_dir=/root
+    Install Standalone Binary    ${file}    target_dir=/root
+    Bootstrap Using Self-Signed Certificate
+
+Install From URL With UPX
+    Skip    TODO
+    Setup Device    image=busybox
+    DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data
+    Bootstrap Using Self-Signed Certificate
+
+Install From URL Without UPX
+    Skip    TODO
+    Setup Device    image=busybox
+    DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data --no-upx
+    Bootstrap Using Self-Signed Certificate
+
+
+*** Keywords ***
+
+Bootstrap Using Self-Signed Certificate
+    [Arguments]    ${install_path}=/data
+
+    ${c8y_domain}=    Cumulocity.Get Domain
+    DeviceLibrary.Execute Command    cmd=sh -c "env C8Y_USER='${C8Y_CONFIG.username}' C8Y_PASSWORD='${C8Y_CONFIG.password}' /data/tedge/bootstrap.sh --c8y-url '${c8y_domain}' --ca self-signed --device-id '${DEVICE_ID}'"
+    
+    Cumulocity.Device Should Exist    ${DEVICE_ID}
+    Cumulocity.Device Should Have Event/s    expected_text=tedge started up.*    type=startup

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,4 @@
+robotframework~=7.0.0
+robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.42.4
+robotframework-devicelibrary[docker] @ git+https://github.com/reubenmiller/robotframework-devicelibrary.git@1.18.0
+robotframework-debuglibrary~=2.5.0

--- a/tests/resources/common.resource
+++ b/tests/resources/common.resource
@@ -1,0 +1,46 @@
+*** Settings ***
+Library     Cumulocity
+Library     DeviceLibrary    bootstrap_script=/dev/null
+
+
+*** Variables ***
+# Cumulocity settings
+&{C8Y_CONFIG}
+...                 host=%{C8Y_BASEURL= }
+...                 username=%{C8Y_USER= }
+...                 password=%{C8Y_PASSWORD= }
+...                 tenant=%{C8Y_TENANT= }
+
+# Docker adapter settings (to control which image is used in the system tests).
+# The user just needs to set the IMAGE env variable
+&{DOCKER_CONFIG}    image=%{TEST_IMAGE=}
+
+
+*** Keywords ***
+Setup Device
+    [Arguments]    ${image}=
+    ${DEVICE_ID}=    DeviceLibrary.Setup    skip_bootstrap=${True}    image=${image}
+    Set Suite Variable    ${DEVICE_ID}
+
+
+Setup Device With Binaries
+    [Arguments]    ${image}=    ${file}=    ${target_dir}=/root
+    ${DEVICE_ID}=    DeviceLibrary.Setup    skip_bootstrap=${True}    image=${image}
+    Set Suite Variable    ${DEVICE_ID}
+    Transfer To Device    ${CURDIR}/../../install.sh    ${target_dir}/
+    Transfer To Device    ${CURDIR}/../../${file}    ${target_dir}/
+
+Setup SysVInit Device With Binaries
+    [Arguments]    ${image}=debian:12    ${file}=    ${target_dir}=/root
+    ${DEVICE_ID}=    DeviceLibrary.Setup    skip_bootstrap=${True}    image=${image}
+
+    Set Suite Variable    ${DEVICE_ID}
+    Transfer To Device    ${CURDIR}/../../install.sh    ${target_dir}/
+    Transfer To Device    ${CURDIR}/../../${file}    ${target_dir}/
+
+Install Standalone Binary
+    [Arguments]    ${file}    ${target_dir}=/root
+    DeviceLibrary.Execute Command    cmd=${target_dir}/install.sh --file ${target_dir}/${file}
+
+Stop Device
+    Cumulocity.Delete Managed Object And Device User    ${DEVICE_ID}


### PR DESCRIPTION
Make it easier to bootstrap the device using different bootstrapping options

* Cumulocity self-signed Certificate
* Cumulocity Certificate Authority
* Cumulocity Basic Auth Credentials

System tests have been added for manual usage for now, with the intention to add to PR checks in the near future.