### PR TITLE
tests: enable install from url tests

### DIFF
--- a/tests/installation_runit_using_c8y_basic_auth.robot
+++ b/tests/installation_runit_using_c8y_basic_auth.robot
@@ -20,13 +20,11 @@ Install From File Without UPX
     Bootstrap Using Basic Authentication
 
 Install From URL With UPX
-    Skip    TODO
     Setup Device    image=busybox
     DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data
     Bootstrap Using Basic Authentication
 
 Install From URL Without UPX
-    Skip    TODO
     Setup Device    image=busybox
     DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data --no-upx
     Bootstrap Using Basic Authentication

--- a/tests/installation_runit_using_c8y_ca.robot
+++ b/tests/installation_runit_using_c8y_ca.robot
@@ -20,13 +20,11 @@ Install From File Without UPX
     Bootstrap Using Certificate Authority
 
 Install From URL With UPX
-    Skip    TODO
     Setup Device    image=busybox
     DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data
     Bootstrap Using Certificate Authority
 
 Install From URL Without UPX
-    Skip    TODO
     Setup Device    image=busybox
     DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data --no-upx
     Bootstrap Using Certificate Authority

--- a/tests/installation_runit_using_c8y_self_signed.robot
+++ b/tests/installation_runit_using_c8y_self_signed.robot
@@ -20,13 +20,11 @@ Install From File Without UPX
     Bootstrap Using Self-Signed Certificate
 
 Install From URL With UPX
-    Skip    TODO
     Setup Device    image=busybox
     DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data
     Bootstrap Using Self-Signed Certificate
 
 Install From URL Without UPX
-    Skip    TODO
     Setup Device    image=busybox
     DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data --no-upx
     Bootstrap Using Self-Signed Certificate


### PR DESCRIPTION
Enable system tests for checking the installation from a URL