### PR TITLE
feat: add update-service.sh wrapper script to enable other service to publish current status

### DIFF
--- a/src/tedge/bin/update-service.sh
+++ b/src/tedge/bin/update-service.sh
@@ -9,12 +9,12 @@ set -e
 #
 # Example on how to use the script within a runit system definition
 #
-# file: service/app1/run
+# file: services/app1/run
 #
 #   $CONFIG_DIR/bin/update-service.sh --register --name app1 --status up
 #   exec /usr/bin/app1
 #
-# file: service/app1/finish
+# file: services/app1/finish
 #
 #   $CONFIG_DIR/bin/update-service.sh --name app1 --status down
 #   sleep 2


### PR DESCRIPTION
This script makes it easier for users to register a service with thin-edge.io locally by just adding the service transitions.

Below shows the example of using the script with a custom runit script.

**Example on how to use the script within a runit system definition**

**file: $CONFIG_DIR/services/app1/run**

Call the update-service.sh script from within the runit service definition which is called when starting your service.

```sh
#!/bin/sh
set -e
# ...load env variable etc.

# register service (no-op if it is already registered)
# and set the status to "up", then start your application (as before)
$CONFIG_DIR/bin/update-service.sh --register --name app1 --status up
exec /usr/bin/app1
```

**file: $CONFIG_DIR/services/app1/finish**

Add a runit "finish" script for the service which is called by the runit service supervisor when the "run" script exits.

```sh
#!/bin/sh
set -e

# set service status to "down" (as the service has been stopped)
$CONFIG_DIR/bin/update-service.sh --name app1 --status down
sleep 2
```
