### PR TITLE
feat: support offline mode when connecting

### DIFF
--- a/docs/oem_poststart.sh
+++ b/docs/oem_poststart.sh
@@ -24,4 +24,5 @@ fi
 /etc/init.d/sshd start ||:
 
 # start thin-edge.io
-@CONFIG_DIR@/bootstrap.sh
+# Note: use --offline as the device's network adapter might not be active yet
+/data/tedge/bootstrap.sh --offline

--- a/tests/installation_runit_using_c8y_basic_auth.robot
+++ b/tests/installation_runit_using_c8y_basic_auth.robot
@@ -19,6 +19,15 @@ Install From File Without UPX
     Install Standalone Binary    ${file}    target_dir=/root
     Bootstrap Using Basic Authentication
 
+Bootstrap Using Offline Mode
+    ${file}=    Set Variable    tedge-standalone-${TARGET.name}-noupx.tar.gz
+    Setup Device With Binaries    image=busybox   file=${file}    target_dir=/data
+    Install Standalone Binary    ${file}    target_dir=/data
+
+    # reduce reconnection time
+    Execute Command    cmd=echo 'MQTT_BRIDGE_RECONNECT_POLICY_MAXIMUM_INTERVAL=5s' >> /data/tedge/env
+    Bootstrap Using Basic Authentication In Offline Mode
+
 Install From URL With UPX
     Setup Device    image=busybox
     DeviceLibrary.Execute Command    cmd=wget -q -O - https://raw.githubusercontent.com/thin-edge/tedge-standalone/main/install.sh | sh -s -- --install-path /data
@@ -41,3 +50,15 @@ Bootstrap Using Basic Authentication
     
     Cumulocity.Device Should Exist    ${DEVICE_ID}
     Cumulocity.Device Should Have Event/s    expected_text=tedge started up.*    type=startup
+
+Bootstrap Using Basic Authentication In Offline Mode
+    [Arguments]    ${install_path}=/data
+
+    ${credentials}=    Cumulocity.Bulk Register Device With Basic Auth       external_id=${DEVICE_ID}
+    ${c8y_domain}=    Cumulocity.Get Domain
+    DeviceLibrary.Disconnect From Network
+    DeviceLibrary.Execute Command    cmd=${install_path}/tedge/bootstrap.sh --c8y-url '${c8y_domain}' --device-user ${credentials.username} --device-password '${credentials.password}' --offline
+
+    DeviceLibrary.Connect To Network
+    Cumulocity.Device Should Exist    ${DEVICE_ID}
+    Cumulocity.Device Should Have Event/s    expected_text=tedge started up.*    type=startup    timeout=90


### PR DESCRIPTION
Add the `--offline` option to the bootstrap.sh to allow bootstrapping when the device may not have an internet connection.

Remove unused code from the oem_poststart.sh example script to align with PSsystec default logic.  The CONFIG_DIR variable reference has also been removed since the PSsystec devices use `/data/tedge` as the installation directory by default, so relying on variable substitution just adds unnecessary complexity.