### PR TITLE
ci: update GitHub Actions to Node.js 24 runtimes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,7 +36,7 @@ jobs:
               name: riscv64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - uses: taiki-e/install-action@just
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload packages as zip
         # https://github.com/marketplace/actions/upload-a-build-artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
             name: tedge-standalone-${{ matrix.target.name }}
             path: |
@@ -73,12 +73,12 @@ jobs:
       needs.build.result == 'success'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: tmp/
       - name: Release

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -53,12 +53,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || '' }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - uses: taiki-e/install-action@just
 
@@ -86,7 +86,7 @@ jobs:
           echo 'TEST_TARGET_NAME="${{ matrix.target.name }}"' >> .env
           cat .env
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version-file: tests/.python-version
           cache: 'pip'
@@ -101,7 +101,7 @@ jobs:
         run: just test
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: reports-${{ matrix.target.name }}-${{ matrix.channel }}-${{ matrix.target.arch }}


### PR DESCRIPTION
## Summary

Update GitHub Actions versions to resolve Node.js 20 deprecation warnings. All updated actions now run on Node.js 24.

## Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `v4` (node20) | `v6` (node24) |
| `actions/upload-artifact` | `v4` (node20) | `v7` (node24) |
| `actions/download-artifact` | `v4` (node20) | `v8` (node24) |
| `actions/setup-python` | `v5` (node20) | `v6` (node24) |
| `docker/setup-buildx-action` | `v3` (node20) | `v4` (node24) |

> **Note:** Requires Actions Runner v2.327.1 or later (GitHub-hosted runners are already updated).