### PR TITLE
fix: create tedge parent logs.path directory if required

### DIFF
--- a/src/tedge/bootstrap.sh
+++ b/src/tedge/bootstrap.sh
@@ -105,6 +105,14 @@ if [ -f "$CONFIG_DIR/env" ]; then
     . "$CONFIG_DIR/env"
 fi
 
+# Create log directory
+# FIXME: in 2.0.1 it seems that the log's parent directory
+# is not created anymore, so it needs to be manually created first
+LOGS_PATH=$(tedge config get logs.path 2>dev/null ||:)
+if [ -n "$LOGS_PATH" ]; then
+    mkdir -p "$LOGS_PATH" ||:
+fi
+
 # Init (also creating the multi-call binary symlinks)
 tedge init
 


### PR DESCRIPTION
In thin-edge.io 2.0.1, the logs.path parent directory needs to be created manually. The bootstrap.sh now ensure it exists before running `tedge init`.