### PR TITLE
fix: adding missing tedge configuration file plugin

### DIFF
--- a/src/tedge/config-plugins/file
+++ b/src/tedge/config-plugins/file
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec tedge run tedge-file-config-plugin "$@"

--- a/src/tedge/tedge.default.toml
+++ b/src/tedge/tedge.default.toml
@@ -18,3 +18,6 @@ plugin_paths = ["@CONFIG_DIR@/log-plugins", "/usr/share/tedge/log-plugins"]
 
 [diag]
 plugin_paths = ["@CONFIG_DIR@/diag-plugins", "/usr/share/tedge/diag-plugins"]
+
+[configuration]
+plugin_paths = ["@CONFIG_DIR@/config-plugins", "/usr/share/tedge/diag-plugins"]


### PR DESCRIPTION
Add the missing tedge configuration file plugin to enable configuration file management.